### PR TITLE
v1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dynamo-types",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "DynamoDB ORM for Typescript",
   "main": "./dst/index.js",
   "typings": "./dst/index.d.ts",

--- a/src/query/full_primary_key.ts
+++ b/src/query/full_primary_key.ts
@@ -68,6 +68,24 @@ export class FullPrimaryKey<T extends Table, HashKeyType, RangeKeyType> {
     };
   }
 
+  async batchDelete(keys: Array<[HashKeyType, RangeKeyType]>) {
+    const res =
+      await this.documentClient.batchWrite({
+        RequestItems: {
+          [this.tableClass.metadata.name]: keys.map(key => {
+            return {
+              DeleteRequest: {
+                Key: {
+                  [this.metadata.hash.name]: key[0],
+                  [this.metadata.range.name]: key[1],
+                },
+              },
+            };
+          }),
+        }
+      }).promise();
+  }
+
   async query(options: {
     hash: HashKeyType,
     range?: RangeKeyOperation.Operations<RangeKeyType>,

--- a/src/query/hash_primary_key.ts
+++ b/src/query/hash_primary_key.ts
@@ -62,6 +62,24 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
     };
   }
 
+
+  async batchDelete(keys: Array<[HashKeyType]>) {
+    const res =
+      await this.documentClient.batchWrite({
+        RequestItems: {
+          [this.tableClass.metadata.name]: keys.map(key => {
+            return {
+              DeleteRequest: {
+                Key: {
+                  [this.metadata.hash.name]: key[0],
+                },
+              },
+            };
+          }),
+        }
+      }).promise();
+  }
+
   // Let'just don't use Scan if it's possible
   // async scan()
   async update(


### PR DESCRIPTION
Implemented BatchDelete

Located at PrimaryKey, since DynamoDB's delete only works with PrimaryKey

